### PR TITLE
chore(release): bump SigNoz to v0.76.2, OTel Collector to vv0.111.36

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.74.3
+version: 0.75.0
 appVersion: "v0.76.2"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1029,7 +1029,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: v0.111.34
+    tag: v0.111.36
     pullPolicy: IfNotPresent
   args:
     - "--up="
@@ -1179,7 +1179,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: v0.111.34
+    tag: v0.111.36
     pullPolicy: IfNotPresent
   # -- Image Registry Secret Names for OtelCollector
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.


### PR DESCRIPTION
#### Summary
 - Release SigNoz v0.76.2
 - Bump SigNoz OTel Collector to vv0.111.36
 - Bump SigNoz Helm chart version to v0.75.0

 Created by [Primus-Bot](https://github.com/apps/primus-bot)